### PR TITLE
Fixed typo, use redhat-uep.pem instead of chemeredhat-uep.pem

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
-rhsm_repo_ca_cert: "{{ '%(ca_cert_dir)s' ~ ('katello-server-ca.pem' if rhsm_method == 'satellite' else 'chemeredhat-uep.pem') }}"
+rhsm_repo_ca_cert: "{{ '%(ca_cert_dir)s' ~ ('katello-server-ca.pem' if rhsm_method == 'satellite' else 'redhat-uep.pem') }}"
 rhsm_full_refresh_on_yum: "{{ 1 if rhsm_method == 'satellite' else 0 }}"
 rhsm_yum_plugins:
   - file: product-id.conf


### PR DESCRIPTION
Hi,

from my point of view there is a typo in vars/main.yml, chemeredhat-uep.pem file does not exist.

Thanks
Robert