### PR TITLE
katello-host-tools package installation fails

### DIFF
--- a/tasks/satellite.yml
+++ b/tasks/satellite.yml
@@ -78,10 +78,3 @@
     - rhsm_satellite
 
 - import_tasks: portal.yml
-
-# https://bugzilla.redhat.com/show_bug.cgi?id=1717093
-- name: SATELLITE 6 | Install katello-host-tools
-  when: rhsm_satellite_version == '6'
-  package:
-    name: katello-host-tools
-    state: present


### PR DESCRIPTION
**Description of Issue:** When subscribing via satellite server, a task is called after registration to install katello-host-tools. 
The task fails with following error:
![image](https://user-images.githubusercontent.com/73195862/162375553-7a0d206c-f16e-41ea-9be4-5a2202136464.png)

**Solution:** The task was added as a workaround for bug: https://bugzilla.redhat.com/show_bug.cgi?id=1717093 
Without adding this package, subscription was getting failed previously. 
Now, addition of this package is not required for successful subscription. 